### PR TITLE
Qt: Make addRow() insert new entry with label from address book

### DIFF
--- a/src/qt/stakingrewardsettingmodel.cpp
+++ b/src/qt/stakingrewardsettingmodel.cpp
@@ -357,7 +357,7 @@ QString StakingRewardSettingTableModel::addRow(const QString &label, const QStri
     priv->findEntry(address, /* lower= */ nullptr, /* upper= */ nullptr, &lowerIndex, /* upperIndex= */ nullptr);
 
     beginInsertRows(QModelIndex(), lowerIndex, lowerIndex);
-    priv->settingEntriesTable.insert(lowerIndex, StakingRewardSettingTableEntry(label, address, percentage));
+    priv->settingEntriesTable.insert(lowerIndex, StakingRewardSettingTableEntry(_label, address, percentage));
     endInsertRows();
 
     return QString::fromStdString(strAddress);


### PR DESCRIPTION
This PR will fix the bug of not getting the label corresponding to the address from address book, in the 'new entry' window of staking reward distribution settings