### PR TITLE
Qt/Translation: Remove text of reward remainder

### DIFF
--- a/src/qt/forms/stakingrewardsettingpage.ui
+++ b/src/qt/forms/stakingrewardsettingpage.ui
@@ -23,7 +23,7 @@
       <enum>Qt::RichText</enum>
      </property>
      <property name="text">
-      <string>You will get a staking reward every time you generate a block according to the following settings.&lt;br&gt;When calculated, each amount of distribution is rounded down to the nearest integer in mochas, and any remainder is sent back together to the captal address.&lt;br&gt;Note: the changes will apply &lt;b&gt;only after&lt;/b&gt; you click OK button.</string>
+      <string>You will get a staking reward every time you generate a block according to the following settings.&lt;br&gt;Each amount of distribution is rounded down to the nearest integer in mochas.&lt;br&gt;Note: the changes will apply &lt;b&gt;only after&lt;/b&gt; you click OK button.</string>
      </property>
     </widget>
    </item>

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -3677,7 +3677,12 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 mocha
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+12"/>
+        <source>You will get a staking reward every time you generate a block according to the following settings.&lt;br&gt;Each amount of distribution is rounded down to the nearest integer in mochas.&lt;br&gt;Note: the changes will apply &lt;b&gt;only after&lt;/b&gt; you click OK button.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3707,12 +3712,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 mocha
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
-        <source>You will get a staking reward every time you generate a block according to the following settings.&lt;br&gt;When calculated, each amount of distribution is rounded down to the nearest integer in mochas, and any remainder is sent back together to the captal address.&lt;br&gt;Note: the changes will apply &lt;b&gt;only after&lt;/b&gt; you click OK button.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+74"/>
+        <location line="+17"/>
         <source>C&amp;opy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3753,17 +3753,13 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 mocha
     </message>
     <message>
         <location line="+6"/>
-        <source>Almost all reward will be sent as above. If there are some XPChains left by rounding, they will be sent back to the captal address.</source>
+        <source>Almost all reward will be sent as above.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <source>The total of distribution percentage must be 100% or less.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+91"/>
-        <source>The total of distribution percentage must be 100% or less</source>
+        <source>The total of distribution percentage must be 100% or less.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/qt/locale/bitcoin_ja.ts
+++ b/src/qt/locale/bitcoin_ja.ts
@@ -2862,6 +2862,10 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 mocha
         <translation>ステーキング報酬の設定</translation>
     </message>
     <message>
+        <source>You will get a staking reward every time you generate a block according to the following settings.&lt;br&gt;Each amount of distribution is rounded down to the nearest integer in mochas.&lt;br&gt;Note: the changes will apply &lt;b&gt;only after&lt;/b&gt; you click OK button.</source>
+        <translation>ブロックを生成すると、以下の設定に従ってステーキング報酬を獲得します。&lt;br&gt;分配量はそれぞれ mocha 単位で切り捨てられます。&lt;br&gt;注意: 変更は、OKボタンをクリック&lt;b&gt;した後に&lt;/b&gt;反映されます。</translation>
+    </message>
+    <message>
         <source>Enter address or label to search</source>
         <translation>検索したいアドレスまたはラベルを入力</translation>
     </message>
@@ -2884,10 +2888,6 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 mocha
     <message>
         <source>&amp;New</source>
         <translation>新規(&amp;N)</translation>
-    </message>
-    <message>
-        <source>You will get a staking reward every time you generate a block according to the following settings.&lt;br&gt;When calculated, each amount of distribution is rounded down to the nearest integer in mochas, and any remainder is sent back together to the captal address.&lt;br&gt;Note: the changes will apply &lt;b&gt;only after&lt;/b&gt; you click OK button.</source>
-        <translation>ブロックを生成すると、以下の設定に従ってステーキング報酬を獲得します。&lt;br&gt;各分配量は計算時に mocha 単位で切り捨てられ、余りは元金アドレスに送り返されます。&lt;br&gt;注意: 変更は、OKボタンをクリック&lt;b&gt;した後に&lt;/b&gt;反映されます。</translation>
     </message>
     <message>
         <source>C&amp;opy</source>
@@ -2922,15 +2922,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 mocha
         <translation>報酬の残り約 %1 %が元金アドレスに送り返されます。</translation>
     </message>
     <message>
-        <source>Almost all reward will be sent as above. If there are some XPChains left by rounding, they will be sent back to the captal address.</source>
-        <translation>ほぼ全額の報酬が上記の通り送られます。小数点以下切り捨ての際に余った XPChain は、元金アドレスに送り返されます。</translation>
+        <source>Almost all reward will be sent as above.</source>
+        <translation>ほぼ全額の報酬が上記の通り送られます。</translation>
     </message>
     <message>
         <source>The total of distribution percentage must be 100% or less.</source>
-        <translation>分配率の合計は100%以下である必要があります。</translation>
-    </message>
-    <message>
-        <source>The total of distribution percentage must be 100% or less</source>
         <translation>分配率の合計は100%以下である必要があります。</translation>
     </message>
 </context>

--- a/src/qt/stakingrewardsettingpage.cpp
+++ b/src/qt/stakingrewardsettingpage.cpp
@@ -249,7 +249,7 @@ void StakingRewardSettingPage::on_okButton_clicked()
     if(totalPct > 100)
     {
         // There's almost no chance to get here because ok button is automatically disabled in calculating of surplus.
-        QMessageBox::critical(this, windowTitle(), tr("The total of distribution percentage must be 100% or less"),
+        QMessageBox::critical(this, windowTitle(), tr("The total of distribution percentage must be 100% or less."),
             QMessageBox::Ok, QMessageBox::Ok);
         returnValue = std::vector<std::pair<std::string, std::uint8_t>>();
         return;

--- a/src/qt/stakingrewardsettingpage.cpp
+++ b/src/qt/stakingrewardsettingpage.cpp
@@ -153,7 +153,7 @@ void StakingRewardSettingPage::calculateSurplus()
     } else if(totalPcts == 100) // No coins will be sent back.
     {
         ui->labelSurplus->setText(
-            tr("Almost all reward will be sent as above. If there are some XPChains left by rounding, they will be sent back to the captal address."));
+            tr("Almost all reward will be sent as above."));
         ui->labelSurplus->setStyleSheet(QString());
         ui->okButton->setEnabled(true);
     } else // Error: thte total of percentage exceeds maximum


### PR DESCRIPTION
This PR will remove description & status message of remainder, which is not born any more, in staking reward distribution.
Contains change of both Qt and translation for easy-to-merge, breaking contribution guidelines.