### PR TITLE
Translation: Fix wrong ja translation of label for expert section

### DIFF
--- a/src/qt/locale/bitcoin_ja.ts
+++ b/src/qt/locale/bitcoin_ja.ts
@@ -1328,7 +1328,7 @@
     </message>
     <message>
         <source>Expert</source>
-        <translation>エクスポート</translation>
+        <translation>上級者向け機能</translation>
     </message>
     <message>
         <source>Enable coin &amp;control features</source>


### PR DESCRIPTION
This PR will fix the wrong Japanese translation of the label for the 'expert' section in the setting window,