### PR TITLE
Wallet: Make description of -minting argument more clear

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -95,7 +95,7 @@ void DummyWalletInit::AddWalletOptions() const
     std::vector<std::string> opts = {"-addresstype", "-changetype", "-disablewallet", "-discardfee=<amt>", "-fallbackfee=<amt>",
         "-keypool=<n>", "-mintxfee=<amt>", "-paytxfee=<amt>", "-rescan", "-salvagewallet", "-spendzeroconfchange",  "-txconfirmtarget=<n>",
         "-upgradewallet", "-wallet=<path>", "-walletbroadcast", "-walletdir=<dir>", "-walletnotify=<cmd>", "-walletrbf", "-zapwallettxes=<mode>",
-        "-dblogsize=<n>", "-flushwallet", "-privdb", "-walletrejectlongchains", "-minting=<n>"};
+        "-dblogsize=<n>", "-flushwallet", "-privdb", "-walletrejectlongchains", "-minting"};
     gArgs.AddHiddenArgs(opts);
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -379,8 +379,6 @@ void SetupServerArgs()
         -GetNumCores(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-persistmempool", strprintf("Whether to save the mempool on shutdown and load on restart (default: %u)", DEFAULT_PERSIST_MEMPOOL), false, OptionsCategory::OPTIONS);
 
-    gArgs.AddArg("-minting","stake",false, OptionsCategory::STAKE);
-
 #ifndef WIN32
     gArgs.AddArg("-pid=<file>", strprintf("Specify pid file. Relative paths will be prefixed by a net-specific datadir location. (default: %s)", XPCHAIN_PID_FILENAME), false, OptionsCategory::OPTIONS);
 #else

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -95,7 +95,7 @@ void DummyWalletInit::AddWalletOptions() const
     std::vector<std::string> opts = {"-addresstype", "-changetype", "-disablewallet", "-discardfee=<amt>", "-fallbackfee=<amt>",
         "-keypool=<n>", "-mintxfee=<amt>", "-paytxfee=<amt>", "-rescan", "-salvagewallet", "-spendzeroconfchange",  "-txconfirmtarget=<n>",
         "-upgradewallet", "-wallet=<path>", "-walletbroadcast", "-walletdir=<dir>", "-walletnotify=<cmd>", "-walletrbf", "-zapwallettxes=<mode>",
-        "-dblogsize=<n>", "-flushwallet", "-privdb", "-walletrejectlongchains"};
+        "-dblogsize=<n>", "-flushwallet", "-privdb", "-walletrejectlongchains", "-minting=<n>"};
     gArgs.AddHiddenArgs(opts);
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -637,8 +637,8 @@ std::string ArgsManager::GetHelpMessage() const
             case OptionsCategory::REGISTER_COMMANDS:
                 usage += HelpMessageGroup("Register Commands:");
                 break;
-            case OptionsCategory::STAKE:
-                usage += HelpMessageGroup("Stake");
+            case OptionsCategory::MINTING:
+                usage += HelpMessageGroup("Minting Options:");
                 break;
             default:
                 break;

--- a/src/util.h
+++ b/src/util.h
@@ -132,7 +132,7 @@ enum class OptionsCategory {
     GUI,
     COMMANDS,
     REGISTER_COMMANDS,
-    STAKE,
+    MINTING,
 
     HIDDEN // Always the last option to avoid printing these in the help
 };

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -87,6 +87,8 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-flushwallet", strprintf("Run a thread to flush wallet periodically (default: %u)", DEFAULT_FLUSHWALLET), true, OptionsCategory::WALLET_DEBUG_TEST);
     gArgs.AddArg("-privdb", strprintf("Sets the DB_PRIVATE flag in the wallet db environment (default: %u)", DEFAULT_WALLET_PRIVDB), true, OptionsCategory::WALLET_DEBUG_TEST);
     gArgs.AddArg("-walletrejectlongchains", strprintf("Wallet will not create transactions that violate mempool chain limits (default: %u)", DEFAULT_WALLET_REJECT_LONG_CHAINS), true, OptionsCategory::WALLET_DEBUG_TEST);
+
+    gArgs.AddArg("-minting","stake",false, OptionsCategory::STAKE);
 }
 
 bool WalletInit::ParameterInteraction() const

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -88,7 +88,7 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-privdb", strprintf("Sets the DB_PRIVATE flag in the wallet db environment (default: %u)", DEFAULT_WALLET_PRIVDB), true, OptionsCategory::WALLET_DEBUG_TEST);
     gArgs.AddArg("-walletrejectlongchains", strprintf("Wallet will not create transactions that violate mempool chain limits (default: %u)", DEFAULT_WALLET_REJECT_LONG_CHAINS), true, OptionsCategory::WALLET_DEBUG_TEST);
 
-    gArgs.AddArg("-minting=<n>", "Whether to mint blocks when the wallet is not locked (0 = no, default: 1)", false, OptionsCategory::MINTING);
+    gArgs.AddArg("-minting", "Whether to mint blocks when the wallet is not locked (0 = no, default: 1)", false, OptionsCategory::MINTING);
 }
 
 bool WalletInit::ParameterInteraction() const

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -88,7 +88,7 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-privdb", strprintf("Sets the DB_PRIVATE flag in the wallet db environment (default: %u)", DEFAULT_WALLET_PRIVDB), true, OptionsCategory::WALLET_DEBUG_TEST);
     gArgs.AddArg("-walletrejectlongchains", strprintf("Wallet will not create transactions that violate mempool chain limits (default: %u)", DEFAULT_WALLET_REJECT_LONG_CHAINS), true, OptionsCategory::WALLET_DEBUG_TEST);
 
-    gArgs.AddArg("-minting","stake",false, OptionsCategory::MINTING);
+    gArgs.AddArg("-minting=<n>", "Whether to mint blocks when the wallet is not locked (0 = no, default: 1)", false, OptionsCategory::MINTING);
 }
 
 bool WalletInit::ParameterInteraction() const

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -88,7 +88,7 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-privdb", strprintf("Sets the DB_PRIVATE flag in the wallet db environment (default: %u)", DEFAULT_WALLET_PRIVDB), true, OptionsCategory::WALLET_DEBUG_TEST);
     gArgs.AddArg("-walletrejectlongchains", strprintf("Wallet will not create transactions that violate mempool chain limits (default: %u)", DEFAULT_WALLET_REJECT_LONG_CHAINS), true, OptionsCategory::WALLET_DEBUG_TEST);
 
-    gArgs.AddArg("-minting","stake",false, OptionsCategory::STAKE);
+    gArgs.AddArg("-minting","stake",false, OptionsCategory::MINTING);
 }
 
 bool WalletInit::ParameterInteraction() const


### PR DESCRIPTION
This PR will
 - change the category of `-minting` argument from “Stake” to “Minting Options”,
 - change the label of “Minting Options”,
 - make the description of the argument more clear,
 - add `-minting` as a hidden argument to dummy wallet's list for when wallet function is disabled (https://github.com/xpc-wg/xpchain/pull/55/commits/c9fea2478259b085fbd2c2ed04028f558b5e41bb)