### PR TITLE
Qt: refactoring KernelRecord

### DIFF
--- a/src/kernelrecord.cpp
+++ b/src/kernelrecord.cpp
@@ -81,7 +81,8 @@ double KernelRecord::getProbToMintStake(double difficulty, int timeOffset) const
     //return target * coinAge / pow(static_cast<double>(2), 256);
     int64_t Weight = (min((GetAdjustedTime() - nTime) + timeOffset, (int64_t)(Params().GetConsensus().nStakeMinAge+Params().GetConsensus().nStakeMaxAge)) - Params().GetConsensus().nStakeMinAge);
     uint64_t coinAge = max(nValue * Weight / (COIN * 86400), (int64_t)0);
-    return coinAge / (pow(static_cast<double>(2),32) * difficulty);
+    double probability = coinAge / (pow(static_cast<double>(2),32) * difficulty);
+    return probability > 1 ? 1 : probability;
 }
 
 double KernelRecord::getProbToMintWithinNMinutes(double difficulty, int minutes)

--- a/src/kernelrecord.cpp
+++ b/src/kernelrecord.cpp
@@ -30,14 +30,12 @@ vector<KernelRecord> KernelRecord::decomposeOutput(const COutPoint& output, cons
     uint32_t n = output.n;
     int64_t nTime = out.time;
     int64_t nValue = out.txout.nValue;
-    int64_t nDayWeight = (min((GetAdjustedTime() - nTime), (int64_t)(Params().GetConsensus().nStakeMaxAge+Params().GetConsensus().nStakeMinAge)) - Params().GetConsensus().nStakeMinAge); // DayWeight * 86400, чтобы был
     CTxDestination address;
     std::string addrStr;
     ExtractDestination(out.txout.scriptPubKey, address);
     addrStr = EncodeDestination(address);
-    uint64_t coinAge = max( (nValue * nDayWeight) / (COIN * 86400), (int64_t)0);
 
-    parts.push_back(KernelRecord(hash, n, nTime, addrStr, nValue, coinAge));
+    parts.push_back(KernelRecord(hash, n, nTime, addrStr, nValue));
     return parts;
 }
 

--- a/src/kernelrecord.h
+++ b/src/kernelrecord.h
@@ -16,20 +16,17 @@ class KernelRecord
 {
 public:
     KernelRecord():
-        hash(), n(), nTime(0), address(""), nValue(0), coinAge(0), prevMinutes(0), prevDifficulty(0), prevProbability(0)
+        hash(), n(), nTime(0), address(""), nValue(0), prevMinutes(0), prevDifficulty(0), prevProbability(0)
     {
     }
 
     KernelRecord(uint256 hash, uint32_t n, int64_t nTime):
-            hash(hash), n(n), nTime(nTime), address(""), nValue(0), coinAge(0), prevMinutes(0), prevDifficulty(0), prevProbability(0)
+            hash(hash), n(n), nTime(nTime), address(""), nValue(0), prevMinutes(0), prevDifficulty(0), prevProbability(0)
     {
     }
 
-    KernelRecord(uint256 hash, uint32_t n, int64_t nTime,
-                 const std::string &address,
-                 int64_t nValue, int64_t coinAge):
-        hash(hash), n(n), nTime(nTime), address(address), nValue(nValue),
-        coinAge(coinAge), prevMinutes(0), prevDifficulty(0), prevProbability(0)
+    KernelRecord(uint256 hash, uint32_t n, int64_t nTime, const std::string &address, int64_t nValue):
+        hash(hash), n(n), nTime(nTime), address(address), nValue(nValue), prevMinutes(0), prevDifficulty(0), prevProbability(0)
     {
     }
 
@@ -42,8 +39,6 @@ public:
     int64_t nTime;
     std::string address;
     int64_t nValue;
-    int idx;
-    int64_t coinAge;
 
     std::string getTxID();
     uint32_t getTxOutIndex();

--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -296,7 +296,7 @@ QVariant MintingTableModel::data(const QModelIndex &index, int role) const
         case Age:
             return (qlonglong)rec->getAge();
         case CoinDay:
-            return (qlonglong)rec->coinAge;
+            return (qlonglong)rec->getCoinDay();
         case Balance:
             return (qlonglong)rec->nValue;
         case MintProbability:
@@ -380,7 +380,7 @@ QString MintingTableModel::formatTxHash(const KernelRecord *wtx) const
 
 QString MintingTableModel::formatTxCoinDay(const KernelRecord *wtx) const
 {
-    return QString::number(wtx->coinAge);
+    return QString::number(wtx->getCoinDay());
 }
 
 QString MintingTableModel::formatTxAge(const KernelRecord *wtx) const


### PR DESCRIPTION
- remove unused variable. (nDayWeight, idx)
- The variable coinAge was actually coinDay. I removed it because I should use the getCoinDay method.
- Fixed the problem that the probability becomes infinite when the probability exceeds 1 during probability calculation.