### PR TITLE
Qt: Improve minting tab refresh process.

### DIFF
--- a/src/kernelrecord.cpp
+++ b/src/kernelrecord.cpp
@@ -15,11 +15,6 @@
 
 using namespace std;
 
-bool KernelRecord::showTransaction()
-{
-    return true;
-}
-
 /*
  * Decompose CWallet transaction to model kernel records.
  */

--- a/src/kernelrecord.h
+++ b/src/kernelrecord.h
@@ -30,7 +30,6 @@ public:
     {
     }
 
-    static bool showTransaction();
     static std::vector<KernelRecord> decomposeOutput(const COutPoint& output, const interfaces::WalletTxOut& out);
 
 

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -8,9 +8,6 @@
 /* Milliseconds between model updates */
 static const int MODEL_UPDATE_DELAY = 250;
 
-/* Milliseconds between mintingtablemodel updates */
-static const int MODEL_MINTING_UPDATE_DELAY = 1000;
-
 /* AskPassphraseDialog -- Maximum passphrase length */
 static const int MAX_PASSPHRASE_SIZE = 1024;
 

--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -81,6 +81,7 @@ public:
     QList<KernelRecord> cachedWallet;
     QList<bool> mask;
     std::vector<KernelRecord> coinQueue;
+    int refresh_limit;
 
     /* Query entire wallet anew from core.
      */
@@ -106,10 +107,12 @@ public:
             {
                 mask.append(false);
             }
+
+            refresh_limit = 50 + ((int)coinQueue.size() / 16);
         }
 
         // Update and add records
-        int limit = 50 + (std::max((int)cachedWallet.size(), (int)coinQueue.size()) / 16);
+        int remain = refresh_limit;
         while(coinQueue.size() > 0)
         {
             // pickup last record
@@ -135,7 +138,7 @@ public:
             }
 
             coinQueue.pop_back(); // faster than erase first record
-            if(--limit == 0){ break; }
+            if(--remain == 0){ break; }
         }
 
         if(coinQueue.size() == 0)


### PR DESCRIPTION
Currently, GUI is returning slow responce if wallet have many UTXOs.
This PR will implove this problem by split refreshing.

- Make shorter refresh interval.
- Limit the number of UTXOs to process in one cycle.

This change sacrifices somewhat the responsiveness in case of a change in the situation of UTXO. However, even if it takes the longest time, updating will be completed in about 4 seconds.
For many users, it will be better than an uncontrollable time.