### PR TITLE
Qt: Fix problem when cancel unlock

### DIFF
--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -281,6 +281,7 @@ void WalletView::decryptForMinting(bool status)
 
         if(walletModel->getEncryptionStatus() != WalletModel::Unlocked){
             fWalletUnlockMintOnly = false;
+            updateEncryptionStatus();
             return;
          }
     }


### PR DESCRIPTION
If you select "unlock for minting only" item in setting menu and cancel it, the item is checked.
This PR fix it.