### PR TITLE
Remove bench_bitcoin and test_bitcoin from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY . /usr/src/xpchain
 WORKDIR /usr/src/xpchain
 RUN \
   ./autogen.sh && \
-  ./configure --without-gui && \
+  ./configure --without-gui --disable-tests --disable-bench && \
   make -j$(nproc) && \
   make install && \
   make clean
@@ -82,7 +82,6 @@ RUN \
 
 # Copy build xpchaind (and other tools)
 COPY --from=build \
-  /usr/local/bin/bench_bitcoin  /usr/local/bin/test_bitcoin \
   /usr/local/bin/xpchain-cli /usr/local/bin/xpchain-tx /usr/local/bin/xpchaind \
   /usr/local/bin/
 


### PR DESCRIPTION
`bench_bitcoin` and `test_bitcoin` are no longer needed to be included in Docker image.

I remove them not only COPY but also from build target so that reduce Docker image size and building time.