### PR TITLE
RPC/REST/ZMQ: Fix listmintings argument count limit

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4765,7 +4765,7 @@ static UniValue listmintings(const JSONRPCRequest& request)
         return NullUniValue;
     }
 
-    if (request.fHelp || request.params.size() > 5)
+    if (request.fHelp || request.params.size() > 6)
         throw std::runtime_error(
             "listmintings ( period minage maxage  [\"addresses\",...] [include_unsafe] [query_options] )\n"
             "\nReturns array of minting status of transaction outputs\n"


### PR DESCRIPTION
The argument limit is 5 like listunspent.
But I added period. So it should be 6.