### PR TITLE
Consensus: enable COINBASE_FLAGS on PoS

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -338,7 +338,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
             coinbaseTx.vout[0].nValue = nBlockReward;
         }
     }
-    coinbaseTx.vin[0].scriptSig = CScript() << nHeight;
+    coinbaseTx.vin[0].scriptSig = (CScript() << nHeight) + COINBASE_FLAGS;
     if (!fPoSHeight) {
         coinbaseTx.vin[0].scriptSig = coinbaseTx.vin[0].scriptSig << OP_0;
     }


### PR DESCRIPTION
``COINBASE_FLAGS`` is defined at validation.cpp L254.
Miner(minter) can set any data organization name that identify them. (example below)
```
const std::string miner_sig = "|ExamplePoSPool|";
const std::vector<unsigned char> miner_sig_sv(miner_sig.begin(), miner_sig.end());
CScript COINBASE_FLAGS = (CScript() << miner_sig_sv);
```
But currently it is not available on PoS phase.
Because it is added to coinbase at ``IncrementExtraNonce`` that not called on PoS.

This change enable ``COINBASE_FLAGS`` on PoS phase.
If miner didn't set data, nothing changes.
Otherwise, extra stuff is added to coinbase. 

Block signature will NOT CORRUPT by this change because it is last part of coinbase scriptSig.
It was already verified on mainnet (e.g. https://insight.xpchain.io/tx/a96d635bf0ae90442ff566e7124d3a1adcf9771c72b39c83b069a926186c276c, created by my custom wallet).